### PR TITLE
fix: plugin env vars now reflect new name

### DIFF
--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -13,7 +13,7 @@ type Config struct {
 type EnvironmentConfigFetcher struct {
 }
 
-const pluginEnvironmentPrefix = "BUILDKITE_PLUGIN_ECS_TASK_RUNNER"
+const pluginEnvironmentPrefix = "BUILDKITE_PLUGIN_MIGRATIONS_RUNNER"
 
 func (f EnvironmentConfigFetcher) Fetch(config *Config) error {
 	return envconfig.Process(pluginEnvironmentPrefix, config)

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -23,22 +23,22 @@ func TestFailOnMissingRequiredEnvironment(t *testing.T) {
 		{
 			name: "all required parameters are unset",
 			disabledEnvVars: []string{
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME",
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND",
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIMEOUT",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_COMMAND",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_TIMEOUT",
 			},
 			enabledEnvVars: map[string]string{},
-			expectedErr:    "required key BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME missing value",
+			expectedErr:    "required key BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME missing value",
 		},
 		{
 			name: "variable COMMAND set",
 			disabledEnvVars: []string{
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME",
 			},
 			enabledEnvVars: map[string]string{
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND": "bin/script",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_COMMAND": "bin/script",
 			},
-			expectedErr: "required key BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME missing value",
+			expectedErr: "required key BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME missing value",
 		},
 	}
 
@@ -72,10 +72,10 @@ func TestSucceedOnMissingOptionalEnvironment(t *testing.T) {
 		{
 			name: "variable COMMAND unset",
 			disabledEnvVars: []string{
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_COMMAND",
 			},
 			enabledEnvVars: map[string]string{
-				"BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME": "test-parameter",
+				"BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME": "test-parameter",
 			},
 		},
 	}
@@ -99,16 +99,16 @@ func TestSucceedOnMissingOptionalEnvironment(t *testing.T) {
 }
 
 func TestFetchConfigFromEnvironment(t *testing.T) {
-	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME")
-	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND")
-	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT")
+	unsetEnv(t, "BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME")
+	unsetEnv(t, "BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_COMMAND")
+	unsetEnv(t, "BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_TIME_OUT")
 
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
 
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME", "test-parameter")
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_COMMAND", "hello-world")
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT", "600")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME", "test-parameter")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_COMMAND", "hello-world")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_TIME_OUT", "600")
 
 	err := fetcher.Fetch(&config)
 
@@ -118,7 +118,7 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 	assert.Equal(t, 600, config.TimeOut, "fetched timeout should match environment")
 
 	// test default value
-	unsetEnv(t, "BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT")
+	unsetEnv(t, "BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_TIME_OUT")
 	err = fetcher.Fetch(&config)
 	require.NoError(t, err, "fetch should not error")
 	assert.Equal(t, 2700, config.TimeOut, "fetched timeout should match environment")

--- a/src/plugin/task-runner_test.go
+++ b/src/plugin/task-runner_test.go
@@ -21,9 +21,9 @@ func (m MockBuildKiteAgent) Annotate(ctx context.Context, message string, style 
 
 func TestRunPluginResponse(t *testing.T) {
 	buildKiteAgent := MockBuildKiteAgent{}
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_PARAMETER_NAME", "test-parameter")
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_SCRIPT", "hello-world")
-	t.Setenv("BUILDKITE_PLUGIN_ECS_TASK_RUNNER_TIME_OUT", "15")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_PARAMETER_NAME", "test-parameter")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_SCRIPT", "hello-world")
+	t.Setenv("BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_TIME_OUT", "15")
 	mockFetcher := plugin.EnvironmentConfigFetcher{}
 	var config plugin.Config
 	err := mockFetcher.Fetch(&config)

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -14,12 +14,12 @@ load '../lib/download.bash'
 
 #TODO: Update this to reflect what we need to test in the task runner code
 setup() {
-  export BUILDKITE_PLUGIN_ECR_TASK_RUNNER_BUILDKITE_PLUGIN_MESSAGE=true
+  export BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_BUILDKITE_PLUGIN_MESSAGE=true
 }
 
 #TODO: Update this to reflect what we need to test in the task runner code
 teardown() {
-    unset BUILDKITE_PLUGIN_ECR_TASK_RUNNER_BUILDKITE_PLUGIN_MESSAGE
+    unset BUILDKITE_PLUGIN_MIGRATIONS_RUNNER_BUILDKITE_PLUGIN_MESSAGE
     rm ./migrations-runner-buildkite-plugin || true
 }
 


### PR DESCRIPTION
## Purpose
- Renaming the plugin from `ecs-task-runner` to `migrations-runner` has also changed the name of the env vars referenced
- This PR fixes this up, [an example of a failing build](https://buildkite.com/culture-amp/permissions-service/builds/2697/canvas?jid=0195ac42-166a-44e5-b9a5-ad28c48e5231) trying to use `v0.0.2`

## Context
- Buildkite plugins follow a convention for env var naming, with the convention being: `BUILDKITE_PLUGIN_${pluginName}_${parameterName}`, all in upper snake case
- initially missed in the find + replace operation in #55, as I was only searching for mentions of `ecs-task-runner`