### PR TITLE
chore: add Claude Code local files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ src/*.html
 
 # Go Release artifacts
 src/dist
+**/.claude/*.local.json
+**/CLAUDE.local.md


### PR DESCRIPTION
> [!NOTE]
> This PR has been raised by automation as part of an initiative to add Claude Code local settings to `.gitignore`.
>
> **Remember**
> 1. We're here to help (#help_sre)
> 2. Please review and merge

# Purpose

- Add `**/.claude/*.local.json` and `**/CLAUDE.local.md` to `.gitignore` so that user-specific Claude Code configuration is not committed.

# Context

Claude Code stores user-specific settings in `.claude/settings.local.json` and local prompt overrides in `CLAUDE.local.md`. These files should not be committed as they contain per-user preferences and local configuration.

Please help us out by:
- Reviewing and merging this PR
